### PR TITLE
getpass

### DIFF
--- a/prompts.py
+++ b/prompts.py
@@ -1,8 +1,9 @@
 from keys import OPENAI_KEY
 import platform
 import os
+import getpass
 
-USERNAME = os.getlogin()
+USERNAME = getpass.getuser()
 OPERATING_SYSTEM = platform.system()
 PYTHON_VERSION = platform.python_version()
 # in need of good prompt engineering


### PR DESCRIPTION
I am working with Python 3.10 in Linuxmint.
When I start engshell.py I got the error:
    USERNAME = os.getlogin()
OSError: [Errno 6] No such device or address

I replaced it with:
USERNAME = getpass.getuser()
which works fine for both Windows 10 and Linuxmint.